### PR TITLE
Added namespacing to the "hidden"

### DIFF
--- a/js/bootstrapx-popoverx.js
+++ b/js/bootstrapx-popoverx.js
@@ -173,7 +173,7 @@
 
 		// provide some callback hooks
         typeof this.options.onHidden == 'function' && this.options.onHidden.call(this);
-        this.$element.trigger('hidden');
+        this.$element.trigger('hidden.popoverx');
       }
     }
     , show: function () {


### PR DESCRIPTION
Done in order to prevent collision with Bootstrap Modal
See Issue:
https://github.com/tshi0912/bootstrapx-popoverx/issues/4
@tshi0912 
